### PR TITLE
added other SE sites that have their own domain

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,7 +12,9 @@
     },
     "content_scripts": [{
         "matches": ["http://*.stackoverflow.com/*",
-            "http://stackoverflow.com/*", "http://*.stackexchange.com/*"
+            "http://stackoverflow.com/*", "http://*.stackexchange.com/*",
+            "http://serverfault.com/*", "http://askubuntu.com/*", 
+            "https://mathoverflow.net/*", "https://stackapps.com/*"
         ],
         "js": ["src/remove.js"],
         "run_at": "document_end"


### PR DESCRIPTION
I noticed when I visited Ask Ubuntu that I could still view Hot Network Qs, so I came to investigate. Added other SE sites that have their own domain, according to this list https://meta.stackexchange.com/questions/248453/why-do-some-stack-exchange-sites-have-their-own-domain-names