### PR TITLE
Simplified matching, added other SE sites that have their own domain

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,10 +11,13 @@
         "128": "icons/128.png"
     },
     "content_scripts": [{
-        "matches": ["http://*.stackoverflow.com/*",
-            "http://stackoverflow.com/*", "http://*.stackexchange.com/*",
-            "http://serverfault.com/*", "http://askubuntu.com/*", 
-            "https://mathoverflow.net/*", "https://stackapps.com/*"
+        "matches": ["*://*.stackoverflow.com/*",
+                    "*://*.stackexchange.com/*",
+                    "*://*.serverfault.com/*",
+                    "*://*.superuser.com/*",
+                    "*://*.askubuntu.com/*",
+                    "*://*.stackapps.com/*",
+                    "*://*.mathoverflow.net/*"
         ],
         "js": ["src/remove.js"],
         "run_at": "document_end"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,7 +12,9 @@
     },
     "content_scripts": [{
         "matches": ["http://*.stackoverflow.com/*",
-            "http://stackoverflow.com/*", "http://*.stackexchange.com/*"
+            "http://stackoverflow.com/*", "http://*.stackexchange.com/*",
+            "http://serverfault.com/*", "http://askubuntu.com/*", 
+            "https://mathoverflow.net/*", "https://stackapps.com/*"
         ],
         "js": ["src/remove.js"],
         "run_at": "document_end"


### PR DESCRIPTION
I went to procrastinate on my work by implementing #2. To make the sites list dynamic, we'd have to request new permissions and complicate things. Given how rarely new sites are added, it's probably not worth it. But I pulled the most recent list of sites from the [SE API](https://api.stackexchange.com/docs/sites#pagesize=999&filter=!6P.EhvygxUiNX&run=true) and manually added them.